### PR TITLE
chore: handle closing change feed stream and logReader during exceptions

### DIFF
--- a/src/outbackcdx/UWeb.java
+++ b/src/outbackcdx/UWeb.java
@@ -53,18 +53,28 @@ public class UWeb {
         }
 
         private void sendResponse(HttpServerExchange exchange, Web.Response response) throws IOException {
-            exchange.setStatusCode(response.getStatus());
-            response.getHeaders().forEach((name, values) -> {
-                for (String value : values) {
-                    exchange.getResponseHeaders().add(HttpString.tryFromString(name), value);
-                }
-            });
             Web.IStreamer streamer = response.getBodyWriter();
-            OutputStream outputStream = exchange.getOutputStream();
-            if (streamer != null) {
-                streamer.stream(outputStream);
+            try {
+                exchange.setStatusCode(response.getStatus());
+                response.getHeaders().forEach((name, values) -> {
+                    for (String value : values) {
+                        exchange.getResponseHeaders().add(HttpString.tryFromString(name), value);
+                    }
+                });
+                OutputStream outputStream = exchange.getOutputStream();
+                if (streamer != null) {
+                    streamer.stream(outputStream);
+                }
+                outputStream.close();
+            } finally {
+                // Streamers that own native resources (e.g. the change feed's
+                // TransactionLogIterator) implement Closeable; close here, after
+                // stream() has returned, so a response aborted before or during
+                // streaming can't leak. close() is idempotent and null-safe.
+                if (streamer instanceof Closeable) {
+                    ((Closeable) streamer).close();
+                }
             }
-            outputStream.close();
         }
 
         public void start() {

--- a/src/outbackcdx/Web.java
+++ b/src/outbackcdx/Web.java
@@ -118,9 +118,19 @@ class Web {
                 }
 
                 if (response != Response.ALREADY_SENT) {
-                    exchange.getResponseHeaders().putAll(response.headers);
-                    exchange.sendResponseHeaders(response.status, response.bodyLength);
-                    response.bodyWriter.stream(exchange.getResponseBody());
+                    try {
+                        exchange.getResponseHeaders().putAll(response.headers);
+                        exchange.sendResponseHeaders(response.status, response.bodyLength);
+                        response.bodyWriter.stream(exchange.getResponseBody());
+                    } finally {
+                        // Close streamers that own native resources (e.g. the
+                        // change feed iterator) after stream() returns, so a
+                        // response aborted before or during streaming can't leak.
+                        // Idempotent and null-safe.
+                        if (response.bodyWriter instanceof Closeable) {
+                            ((Closeable) response.bodyWriter).close();
+                        }
+                    }
                 }
             } finally {
                 exchange.close();

--- a/src/outbackcdx/Webapp.java
+++ b/src/outbackcdx/Webapp.java
@@ -415,9 +415,10 @@ class Webapp implements Web.Handler {
         return new Response(OK, "text/plain", output);
     }
 
-    static class ChangeFeedJsonStream implements IStreamer {
-        TransactionLogIterator logReader;
-        long batchSize;
+    static class ChangeFeedJsonStream implements IStreamer, Closeable {
+        final TransactionLogIterator logReader;
+        final long batchSize;
+        private boolean closed = false;
 
         ChangeFeedJsonStream(TransactionLogIterator logReader, long batchSize) {
             this.logReader = logReader;
@@ -464,6 +465,23 @@ class Webapp implements Web.Handler {
                 output.write("\n]\n".getBytes(UTF_8));
                 output.flush();
             } finally {
+                close();
+            }
+        }
+
+        /**
+         * Frees the native TransactionLogIterator, exactly once. Idempotent so
+         * both stream()'s finally and the server's finally -- which runs after
+         * stream() returns (see UWeb.sendResponse / Web.handle) -- can call it
+         * safely. The server's call is what prevents a leak when an aborted
+         * response means stream() is never invoked. logReader is never closed
+         * while stream() may still be iterating it; that use-after-free was the
+         * original segfault.
+         */
+        @Override
+        public synchronized void close() {
+            if (!closed) {
+                closed = true;
                 logReader.close();
             }
         }
@@ -483,16 +501,9 @@ class Webapp implements Web.Handler {
             out.printf("%s Received request %s. Retrieving deltas for collection <%s> since sequenceNumber %s%n", new Date(), request, collection, since);
         }
 
+        TransactionLogIterator logReader;
         try {
-            /* This method must not close logReader, or you will get a segfault.
-             * The response payload stream class ChangeFeedJsonStream closes it
-             * when it's finished with it. */
-            TransactionLogIterator logReader = index.getUpdatesSince(since);
-
-            ChangeFeedJsonStream streamer = new ChangeFeedJsonStream(logReader, size);
-            Response response = new Response(OK, "application/json", streamer);
-            response.addHeader("Access-Control-Allow-Origin", "*");
-            return response;
+            logReader = index.getUpdatesSince(since);
         } catch (RocksDBException e) {
             System.err.println(new Date() + " " + request.method() + " " + request.url() + " - " + e);
             if (!"Requested sequence not yet written in the db".equals(e.getMessage())) {
@@ -500,6 +511,25 @@ class Webapp implements Web.Handler {
             }
             throw new Web.ResponseException(
                     new Response(INTERNAL_ERROR, "text/plain", e + "\n"));
+        }
+
+        /*
+         * logReader is an owning native handle. Ownership transfers to the
+         * streamer -- which the server closes after stream(), see
+         * UWeb.sendResponse / Web.handle -- only once we successfully return the
+         * Response. If constructing/returning it throws first, the server never
+         * receives the streamer, so we must close logReader here. Do NOT close
+         * on the success path: stream() runs later and would hit a freed handle,
+         * which is the segfault the previous comment warned about.
+         */
+        try {
+            ChangeFeedJsonStream streamer = new ChangeFeedJsonStream(logReader, size);
+            Response response = new Response(OK, "application/json", streamer);
+            response.addHeader("Access-Control-Allow-Origin", "*");
+            return response;
+        } catch (RuntimeException | Error e) {
+            logReader.close();
+            throw e;
         }
     }
 


### PR DESCRIPTION
Not yet tested, but this is an attempt to:

Handle closing log reader when it's been passed off to the stream. During exceptions, like the client disconnecting before reading everything, the handle will get dropped without being closed. If we make the stream `Closeable`, we can ensure it is closed during response exceptions. 